### PR TITLE
Address authentication dialog not closing on Win build 1903 and Office build 1907

### DIFF
--- a/src/helpers/dialog.ts
+++ b/src/helpers/dialog.ts
@@ -74,6 +74,9 @@ export class Dialog<T> {
       else if (Utilities.isAddin) {
         this._result = this._addinDialog();
       }
+      else if (Utilities.isEdge) {
+        this._result = this._edgeDialog();
+      }
       else {
         this._result = this._webDialog();
       }
@@ -124,7 +127,7 @@ export class Dialog<T> {
       try {
         const options = 'width=' + this.size.width + ',height=' + this.size.height + this._windowFeatures;
         window.open(this.url, this.url, options);
-        if (Utilities.isIEOrEdge) {
+        if (Utilities.isIE) {
           this._pollLocalStorageForToken(resolve, reject);
         }
         else {
@@ -140,6 +143,19 @@ export class Dialog<T> {
       catch (exception) {
         return reject(new DialogError('Unexpected error occurred while creating popup', exception));
       }
+    });
+  }
+
+  private _edgeDialog(): Promise<T> {
+    return new Promise((resolve, reject) => {
+      Office.context.ui.displayDialogAsync(this.url, { width: this.size.width$, height: this.size.height$ }, (result: Office.AsyncResult) => {
+        if (result.status === Office.AsyncResultStatus.Failed) {
+          reject(new DialogError(result.error.message, result.error));
+        }
+        else {
+          this._pollLocalStorageForToken(resolve, reject);
+        }
+      });
     });
   }
 

--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -181,7 +181,7 @@ export class Utilities {
    * Utility to check if the code is running inside of an add-in.
    */
   static get isAddin() {
-    return Utilities.host !== HostType.WEB;
+    return Utilities.host !== HostType.WEB && !Utilities.isEdge;
   }
 
   /**

--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -185,10 +185,24 @@ export class Utilities {
   }
 
   /**
+   * Utility to check if the browser is IE11.
+   */
+  static get isIE() {
+    return /Trident\//gi.test(window.navigator.userAgent);
+  }
+
+  /**
+   * Utility to check if the browser is Edge.
+   */
+  static get isEdge() {
+    return /Edge\//gi.test(window.navigator.userAgent);
+  }
+
+  /**
    * Utility to check if the browser is IE11 or Edge.
    */
   static get isIEOrEdge() {
-    return /Edge\/|Trident\//gi.test(window.navigator.userAgent);
+    return Utilities.isIE || Utilities.isEdge;
   }
 
   /**


### PR DESCRIPTION
This fix is intended to address authentication issues with both Office 365 with Edge and the desktop versions of Office as of the recent 1903 Windows update, paired with the 1907 update of Office.

We found that for the online version of Office apps running on Edge, the taskpane instance of add-ins would believe that it were running in an add-in environment, but the dialog pop-up would determine that it was in a web environment. This mismatch prevents add-ins from communicating with the dialogs they open for authentication, since add-ins would wait for message events, while dialogs would only set an entry in localStorage.

The fix in this PR is to separate the handling of Edge as a special case and to rely solely on localStorage for both the desktop and online versions of Office apps. We decided to do this because we experienced inconsistent message sending behavior on Edge, whereas localStorage had proven to be more stable.